### PR TITLE
feat: 문장 위치 분석 로직 개선 및 블러 효과 오버레이 방식으로 전환

### DIFF
--- a/apps/extension/src/__tests__/content.test.tsx
+++ b/apps/extension/src/__tests__/content.test.tsx
@@ -1,13 +1,15 @@
 import { act } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { splitParagraph } from '../utils/splitParagraph';
+type StorageChangeListener = (
+  changes: { [key: string]: chrome.storage.StorageChange },
+  areaName: string,
+) => void;
 
 const waitForDom = () => new Promise((resolve) => setTimeout(resolve, 50));
 
 /**
  * MutationObserver 추적을 위한 래퍼
- * 이전 테스트의 observer가 이후 테스트의 DOM을 처리하는 것을 방지
  */
 const trackedObservers: MutationObserver[] = [];
 const OriginalMutationObserver = globalThis.MutationObserver;
@@ -36,9 +38,6 @@ describe('Content Script 통합 테스트', () => {
     vi.clearAllMocks();
   });
 
-  /**
-   * ON 상태로 content script를 초기화하는 헬퍼
-   */
   const setupOnState = async (html?: string) => {
     vi.mocked(chrome.storage.local.get).mockImplementation(
       (keys, callback) => {
@@ -57,40 +56,24 @@ describe('Content Script 통합 테스트', () => {
     });
   };
 
-  /**
-   * storage 변경 이벤트를 발생시켜 OFF 전환을 트리거하는 헬퍼
-   *
-   * App.tsx와 content.tsx 모두 onChanged.addListener를
-   * 등록하므로, 실제 Chrome 동작처럼 모든 리스너를 호출
-   */
-  const triggerOff = async () => {
-    type StorageChangeListener = (
-      changes: {
-        [key: string]: chrome.storage.StorageChange;
-      },
-      areaName: string,
-    ) => void;
-
-    const calls = vi.mocked(
-      chrome.storage.onChanged.addListener,
-    ).mock.calls;
-
-    const changes = {
-      wandokEnabled: {
-        newValue: false,
-        oldValue: true,
-      },
-    };
+  const triggerStorageChange = async (
+    changes: { [key: string]: chrome.storage.StorageChange },
+    areaName: string,
+  ) => {
+    const calls = vi.mocked(chrome.storage.onChanged.addListener).mock.calls;
 
     await act(() => {
       calls.forEach(([listener]) => {
-        (listener as StorageChangeListener)(
-          changes,
-          'local',
-        );
+        (listener as StorageChangeListener)(changes, areaName);
       });
     });
   };
+
+  const triggerOff = () =>
+    triggerStorageChange(
+      { wandokEnabled: { newValue: false, oldValue: true } },
+      'local',
+    );
 
   describe('초기 상태', () => {
     it('OFF일 때 shadow host가 DOM에 없어야 한다', async () => {
@@ -105,147 +88,86 @@ describe('Content Script 통합 테스트', () => {
         await waitForDom();
       });
 
-      const shadowHost = document.getElementById('wandok-shadow-host');
-
-      expect(shadowHost).toBeNull();
+      expect(document.getElementById('wandok-shadow-host')).toBeNull();
     });
 
-    it('ON일 때 ProgressBar가 있어야 한다', async () => {
-      vi.mocked(chrome.storage.local.get).mockImplementation((keys, callback) => {
-        if (callback) callback({ wandokEnabled: true });
-        return Promise.resolve({ wandokEnabled: true });
-      });
+    it('ON일 때 shadow host가 DOM에 있어야 한다', async () => {
+      await setupOnState();
 
-      vi.resetModules();
-      await act(async () => {
-        await import('../content');
-        await waitForDom();
-      });
-
-      const shadowHost = document.getElementById('wandok-shadow-host');
-      const shadowRoot = shadowHost?.shadowRoot;
-      const progressBar = shadowRoot?.querySelector('.fixed.top-0.right-0');
-
-      expect(progressBar).not.toBeNull();
+      expect(document.getElementById('wandok-shadow-host')).not.toBeNull();
     });
   });
 
-  describe('ON → OFF 전환 시 스타일 복구', () => {
-    it('블러 효과가 모두 제거되어야 한다', async () => {
-      const html = `
-        <article>
-          <p>첫 번째 문장입니다. 두 번째 문장입니다.</p>
-          <p>세 번째 문장입니다. 네 번째 문장입니다.</p>
-        </article>
-      `;
-
-      await setupOnState(html);
-
-      // content script가 텍스트를 처리했는지 확인
-      const spans = document.querySelectorAll(
-        '.wandok-text-wrapper',
-      );
-      expect(spans.length).toBeGreaterThan(0);
-
-      // 블러 상태 시뮬레이션: 문단에 직접 blur 클래스 추가
-      const paragraphs =
-        document.querySelectorAll('article p');
-      paragraphs.forEach((p) =>
-        p.classList.add('wandok-blur'),
-      );
-
-      expect(
-        document.querySelectorAll('.wandok-blur').length,
-      ).toBe(2);
-
-      await triggerOff();
-
-      expect(
-        document.querySelectorAll('.wandok-blur').length,
-      ).toBe(0);
-    });
-
-    it('분리된 문단이 원래 상태로 복원되어야 한다', async () => {
+  describe('원본 DOM 비변경 검증', () => {
+    it('ON 상태에서 원본 DOM에 wandok-text-wrapper가 없어야 한다', async () => {
       await setupOnState();
 
-      const initialCount =
-        document.querySelectorAll('article p').length;
-
-      // splitParagraph로 문단 분리 시뮬레이션
-      const secondSpan = document.querySelectorAll(
-        '.wandok-text-wrapper',
-      )[1] as HTMLElement;
-      splitParagraph(secondSpan);
-
-      expect(
-        document.querySelectorAll(
-          '.wandok-split-paragraph',
-        ).length,
-      ).toBe(1);
-
-      await triggerOff();
-
-      expect(
-        document.querySelectorAll(
-          '.wandok-split-paragraph',
-        ).length,
-      ).toBe(0);
-      expect(
-        document.querySelectorAll('article p').length,
-      ).toBe(initialCount);
+      expect(document.querySelectorAll('.wandok-text-wrapper').length).toBe(0);
     });
 
-    it('블러 제거와 문단 복원이 동시에 수행되어야 한다', async () => {
-      const html = `
-        <article>
-          <p>첫 번째 문장입니다. 두 번째 문장입니다.</p>
-          <p>세 번째 문장입니다. 네 번째 문장입니다.</p>
-        </article>
-      `;
+    it('ON 상태에서 원본 DOM에 wandok-blur 클래스가 없어야 한다', async () => {
+      await setupOnState();
 
-      await setupOnState(html);
+      expect(document.querySelectorAll('.wandok-blur').length).toBe(0);
+    });
 
-      const initialCount =
-        document.querySelectorAll('article p').length;
+    it('ON 상태에서 원본 DOM에 wandok-split-paragraph가 없어야 한다', async () => {
+      await setupOnState();
 
-      // 문단 분리
-      const secondSpan = document.querySelectorAll(
-        '.wandok-text-wrapper',
-      )[1] as HTMLElement;
-      splitParagraph(secondSpan);
+      expect(document.querySelectorAll('.wandok-split-paragraph').length).toBe(0);
+    });
+  });
 
-      // 블러 적용
-      document
-        .querySelectorAll('article p')
-        .forEach((p) => p.classList.add('wandok-blur'));
+  describe('CustomEvent 발행', () => {
+    it('ON 전환 시 wandok:activated 이벤트가 발행되어야 한다', async () => {
+      const handler = vi.fn();
+      window.addEventListener('wandok:activated', handler);
 
-      expect(
-        document.querySelectorAll('.wandok-blur').length,
-      ).toBeGreaterThan(0);
-      expect(
-        document.querySelectorAll(
-          '.wandok-split-paragraph',
-        ).length,
-      ).toBeGreaterThan(0);
+      await setupOnState();
+
+      expect(handler).toHaveBeenCalled();
+
+      window.removeEventListener('wandok:activated', handler);
+    });
+
+    it('OFF 전환 시 wandok:deactivated 이벤트가 발행되어야 한다', async () => {
+      await setupOnState();
+      const handler = vi.fn();
+      window.addEventListener('wandok:deactivated', handler);
 
       await triggerOff();
 
-      expect(
-        document.querySelectorAll('.wandok-blur').length,
-      ).toBe(0);
-      expect(
-        document.querySelectorAll(
-          '.wandok-split-paragraph',
-        ).length,
-      ).toBe(0);
-      expect(
-        document.querySelectorAll('article p').length,
-      ).toBe(initialCount);
+      expect(handler).toHaveBeenCalled();
+
+      window.removeEventListener('wandok:deactivated', handler);
+    });
+  });
+
+  describe('ON → OFF 전환', () => {
+    it('shadow host가 DOM에서 제거되어야 한다', async () => {
+      await setupOnState();
+      expect(document.getElementById('wandok-shadow-host')).not.toBeNull();
+
+      await triggerOff();
+
+      expect(document.getElementById('wandok-shadow-host')).toBeNull();
+    });
+
+    it('spacer가 모두 제거되어야 한다', async () => {
+      await setupOnState();
+      const spacer = document.createElement('br');
+      spacer.className = 'wandok-spacer';
+      document.querySelector('article p')?.appendChild(spacer);
+      expect(document.querySelectorAll('.wandok-spacer').length).toBe(1);
+
+      await triggerOff();
+
+      expect(document.querySelectorAll('.wandok-spacer').length).toBe(0);
     });
   });
 
   describe('콘텐츠 필터링', () => {
-    it('article 밖의 텍스트는 처리하지 않아야 한다', async () => {
+    it('article 밖의 텍스트는 분석하지 않아야 한다', async () => {
       const html = `
         <nav><p>네비게이션 텍스트</p></nav>
         <article><p>본문 텍스트입니다.</p></article>
@@ -254,153 +176,14 @@ describe('Content Script 통합 테스트', () => {
 
       await setupOnState(html);
 
-      const navSpans = document.querySelectorAll('nav .wandok-text-wrapper');
-      const footerSpans = document.querySelectorAll('footer .wandok-text-wrapper');
-      const articleSpans = document.querySelectorAll('article .wandok-text-wrapper');
-
-      expect(navSpans.length).toBe(0);
-      expect(footerSpans.length).toBe(0);
-      expect(articleSpans.length).toBeGreaterThan(0);
-    });
-
-    it('button, a 태그 내부의 텍스트는 처리하지 않아야 한다', async () => {
-      const html = `
-        <article>
-          <p>본문 텍스트입니다.</p>
-          <button>버튼 텍스트</button>
-          <a href="#">링크 텍스트</a>
-        </article>
-      `;
-
-      await setupOnState(html);
-
-      const buttonSpans = document.querySelectorAll('button .wandok-text-wrapper');
-      const linkSpans = document.querySelectorAll('a .wandok-text-wrapper');
-
-      expect(buttonSpans.length).toBe(0);
-      expect(linkSpans.length).toBe(0);
-    });
-  });
-
-  describe('비활성 상태 동작', () => {
-    it('OFF 전환 시 wandok-text-wrapper가 제거되어 클릭할 대상이 없어야 한다', async () => {
-      await setupOnState();
-
-      const spans = document.querySelectorAll('.wandok-text-wrapper');
-      expect(spans.length).toBeGreaterThan(0);
-
-      await triggerOff();
-
+      expect(document.getElementById('wandok-shadow-host')).not.toBeNull();
       expect(document.querySelectorAll('.wandok-text-wrapper').length).toBe(0);
-      expect(document.querySelectorAll('.wandok-split-paragraph').length).toBe(0);
-    });
-
-    it('OFF 전환 시 wandok-text-wrapper가 모두 제거되고 원본 텍스트가 복원되어야 한다', async () => {
-      const html = `
-        <article>
-          <p>첫 번째 문장입니다. 두 번째 문장입니다.</p>
-          <p>세 번째 문장입니다. 네 번째 문장입니다.</p>
-        </article>
-      `;
-
-      await setupOnState(html);
-
-      expect(document.querySelectorAll('.wandok-text-wrapper').length).toBeGreaterThan(0);
-
-      await triggerOff();
-
-      expect(document.querySelectorAll('.wandok-text-wrapper').length).toBe(0);
-
-      const paragraphs = document.querySelectorAll('article p');
-      expect(paragraphs.length).toBe(2);
-      expect(paragraphs[0].textContent).toContain('첫 번째 문장입니다.');
-      expect(paragraphs[1].textContent).toContain('세 번째 문장입니다.');
-    });
-  });
-
-  describe('이벤트 전파', () => {
-    it('ON 상태에서 wandok-text-wrapper 클릭 시 부모 요소로 이벤트가 전파되어야 한다', async () => {
-      await setupOnState();
-
-      const article = document.querySelector('article') as HTMLElement;
-      const clickHandler = vi.fn();
-      article.addEventListener('click', clickHandler);
-
-      const span = document.querySelector('.wandok-text-wrapper') as HTMLElement;
-      span.click();
-
-      expect(clickHandler).toHaveBeenCalledTimes(1);
-
-      article.removeEventListener('click', clickHandler);
-    });
-
-    it('ON 상태에서 클릭 이벤트가 document까지 전파되어야 한다', async () => {
-      await setupOnState();
-
-      const clickHandler = vi.fn();
-      document.addEventListener('click', clickHandler);
-
-      const span = document.querySelector('.wandok-text-wrapper') as HTMLElement;
-      span.click();
-
-      expect(clickHandler).toHaveBeenCalledTimes(1);
-
-      document.removeEventListener('click', clickHandler);
-    });
-  });
-
-  describe('이벤트 핸들러', () => {
-    it('ON 상태에서 wandok-text-wrapper 클릭 시 문단이 분리되어야 한다', async () => {
-      await setupOnState();
-
-      const spans = document.querySelectorAll('.wandok-text-wrapper');
-      expect(spans.length).toBeGreaterThan(1);
-
-      const secondSpan = spans[1] as HTMLElement;
-      await act(async () => {
-        secondSpan.click();
-        await waitForDom();
-      });
-
-      expect(document.querySelectorAll('.wandok-split-paragraph').length).toBeGreaterThan(0);
-    });
-
-    it('ON 상태에서 마우스 호버 시 블러 효과가 적용되어야 한다', async () => {
-      const html = `
-        <article>
-          <p>첫 번째 문장입니다. 두 번째 문장입니다.</p>
-          <p>세 번째 문장입니다. 네 번째 문장입니다.</p>
-        </article>
-      `;
-      await setupOnState(html);
-
-      const spans = document.querySelectorAll('.wandok-text-wrapper');
-      expect(spans.length).toBeGreaterThan(0);
-
-      const firstSpan = spans[0] as HTMLElement;
-      await act(async () => {
-        firstSpan.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
-        await waitForDom();
-      });
-
-      const blurredElements = document.querySelectorAll('.wandok-blur');
-      expect(blurredElements.length).toBeGreaterThan(0);
-
-      await act(async () => {
-        firstSpan.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }));
-        await waitForDom();
-      });
-
-      expect(document.querySelectorAll('.wandok-blur').length).toBe(0);
     });
   });
 
   describe('MutationObserver', () => {
-    it('동적으로 추가된 article 내 콘텐츠를 처리해야 한다', async () => {
+    it('동적으로 추가된 article 내 콘텐츠도 처리해야 한다', async () => {
       await setupOnState();
-
-      const initialSpans = document.querySelectorAll('.wandok-text-wrapper').length;
-
       const article = document.querySelector('article');
       const newParagraph = document.createElement('p');
       newParagraph.textContent = '동적으로 추가된 문장입니다.';
@@ -410,239 +193,31 @@ describe('Content Script 통합 테스트', () => {
         await waitForDom();
       });
 
-      const afterSpans = document.querySelectorAll('.wandok-text-wrapper').length;
-      expect(afterSpans).toBeGreaterThan(initialSpans);
-    });
-
-    it('wandok-split-paragraph 요소가 추가되어도 재처리하지 않아야 한다', async () => {
-      await setupOnState();
-
-      const article = document.querySelector('article');
-      const splitParagraphEl = document.createElement('p');
-      splitParagraphEl.classList.add('wandok-split-paragraph');
-      splitParagraphEl.innerHTML = '<span class="wandok-text-wrapper">이미 처리된 텍스트</span>';
-
-      await act(async () => {
-        article?.appendChild(splitParagraphEl);
-        await waitForDom();
-      });
-
-      const wrappersInSplit = splitParagraphEl.querySelectorAll('.wandok-text-wrapper');
-      expect(wrappersInSplit.length).toBe(1);
-    });
-
-    it('wandok-text-wrapper 요소가 추가되어도 재처리하지 않아야 한다', async () => {
-      await setupOnState();
-
-      const article = document.querySelector('article');
-      const wrapper = document.createElement('span');
-      wrapper.classList.add('wandok-text-wrapper');
-      wrapper.textContent = '이미 래핑된 텍스트';
-
-      await act(async () => {
-        article?.appendChild(wrapper);
-        await waitForDom();
-      });
-
-      const nestedWrappers = wrapper.querySelectorAll('.wandok-text-wrapper');
-      expect(nestedWrappers.length).toBe(0);
-    });
-
-    it('wandok-text-wrapper를 포함한 요소가 추가되어도 재처리하지 않아야 한다', async () => {
-      await setupOnState();
-
-      const article = document.querySelector('article');
-      const container = document.createElement('div');
-      container.innerHTML = '<span class="wandok-text-wrapper">이미 처리된 텍스트</span>';
-
-      await act(async () => {
-        article?.appendChild(container);
-        await waitForDom();
-      });
-
-      const wrappers = container.querySelectorAll('.wandok-text-wrapper');
-      expect(wrappers.length).toBe(1);
-    });
-  });
-
-  describe('OFF → ON 재활성화', () => {
-    /**
-     * storage 변경 이벤트를 발생시켜 ON 전환을 트리거하는 헬퍼
-     */
-    const triggerOn = async () => {
-      type StorageChangeListener = (
-        changes: {
-          [key: string]: chrome.storage.StorageChange;
-        },
-        areaName: string,
-      ) => void;
-
-      const calls = vi.mocked(
-        chrome.storage.onChanged.addListener,
-      ).mock.calls;
-
-      const changes = {
-        wandokEnabled: {
-          newValue: true,
-          oldValue: false,
-        },
-      };
-
-      await act(() => {
-        calls.forEach(([listener]) => {
-          (listener as StorageChangeListener)(
-            changes,
-            'local',
-          );
-        });
-      });
-    };
-
-    it('OFF → ON 재활성화 시 텍스트가 다시 래핑되어야 한다', async () => {
-      await setupOnState();
-
-      expect(document.querySelectorAll('.wandok-text-wrapper').length).toBeGreaterThan(0);
-
-      await triggerOff();
-
       expect(document.querySelectorAll('.wandok-text-wrapper').length).toBe(0);
-
-      await triggerOn();
-      await act(async () => {
-        await waitForDom();
-      });
-
-      expect(document.querySelectorAll('.wandok-text-wrapper').length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('OFF 전환 시 원본 텍스트 복원', () => {
-    it('문장 사이 공백이 보존되어야 한다', async () => {
-      const html = `
-        <article>
-          <p>첫 번째 문장입니다. 두 번째 문장입니다.</p>
-        </article>
-      `;
-      await setupOnState(html);
-
-      const p = document.querySelector('article p') as HTMLElement;
-      expect(p.querySelectorAll('.wandok-text-wrapper').length).toBeGreaterThan(0);
-
-      await triggerOff();
-
-      expect(p.textContent).toBe('첫 번째 문장입니다. 두 번째 문장입니다.');
-    });
-
-    it('약어가 포함된 텍스트의 공백이 보존되어야 한다', async () => {
-      const html = `
-        <article>
-          <p>Mr. Smith visited Dr. Lee at the hospital. Prof. Kim was also there.</p>
-        </article>
-      `;
-      await setupOnState(html);
-
-      await triggerOff();
-
-      const p = document.querySelector('article p') as HTMLElement;
-      expect(p.textContent).toBe(
-        'Mr. Smith visited Dr. Lee at the hospital. Prof. Kim was also there.',
-      );
-    });
-
-    it('한영 혼합 텍스트의 공백이 보존되어야 한다', async () => {
-      const html = `
-        <article>
-          <p>안녕하세요, 제 이름은 Alice 입니다. Bob의 친구입니다.</p>
-        </article>
-      `;
-      await setupOnState(html);
-
-      await triggerOff();
-
-      const p = document.querySelector('article p') as HTMLElement;
-      expect(p.textContent).toBe('안녕하세요, 제 이름은 Alice 입니다. Bob의 친구입니다.');
-    });
-
-    it('문단 분리 후 복원해도 원본 텍스트가 보존되어야 한다', async () => {
-      const html = `
-        <article>
-          <p>첫 번째 문장입니다. 두 번째 문장입니다. 세 번째 문장입니다.</p>
-        </article>
-      `;
-      await setupOnState(html);
-
-      const secondSpan = document.querySelectorAll('.wandok-text-wrapper')[1] as HTMLElement;
-      splitParagraph(secondSpan);
-
-      expect(document.querySelectorAll('.wandok-split-paragraph').length).toBe(1);
-
-      await triggerOff();
-
-      const paragraphs = document.querySelectorAll('article p');
-      expect(paragraphs.length).toBe(1);
-      expect(paragraphs[0].textContent).toBe(
-        '첫 번째 문장입니다. 두 번째 문장입니다. 세 번째 문장입니다.',
-      );
     });
   });
 
   describe('storage 변경 엣지 케이스', () => {
     it('local이 아닌 storage 변경은 무시해야 한다', async () => {
-      const html = `
-        <article>
-          <p>첫 번째 문장입니다. 두 번째 문장입니다.</p>
-        </article>
-      `;
-      await setupOnState(html);
+      await setupOnState();
 
-      document.querySelectorAll('article p').forEach((p) => p.classList.add('wandok-blur'));
-      expect(document.querySelectorAll('.wandok-blur').length).toBeGreaterThan(0);
+      await triggerStorageChange(
+        { wandokEnabled: { newValue: false, oldValue: true } },
+        'sync',
+      );
 
-      type StorageChangeListener = (
-        changes: { [key: string]: chrome.storage.StorageChange },
-        areaName: string,
-      ) => void;
-
-      const calls = vi.mocked(chrome.storage.onChanged.addListener).mock.calls;
-      await act(() => {
-        calls.forEach(([listener]) => {
-          (listener as StorageChangeListener)(
-            { wandokEnabled: { newValue: false, oldValue: true } },
-            'sync',
-          );
-        });
-      });
-
-      expect(document.querySelectorAll('.wandok-blur').length).toBeGreaterThan(0);
+      expect(document.getElementById('wandok-shadow-host')).not.toBeNull();
     });
 
     it('wandokEnabled 외의 storage 변경은 무시해야 한다', async () => {
-      const html = `
-        <article>
-          <p>첫 번째 문장입니다. 두 번째 문장입니다.</p>
-        </article>
-      `;
-      await setupOnState(html);
+      await setupOnState();
 
-      document.querySelectorAll('article p').forEach((p) => p.classList.add('wandok-blur'));
-      expect(document.querySelectorAll('.wandok-blur').length).toBeGreaterThan(0);
+      await triggerStorageChange(
+        { someOtherKey: { newValue: 'new', oldValue: 'old' } },
+        'local',
+      );
 
-      type StorageChangeListener = (
-        changes: { [key: string]: chrome.storage.StorageChange },
-        areaName: string,
-      ) => void;
-
-      const calls = vi.mocked(chrome.storage.onChanged.addListener).mock.calls;
-      await act(() => {
-        calls.forEach(([listener]) => {
-          (listener as StorageChangeListener)(
-            { someOtherKey: { newValue: 'new', oldValue: 'old' } },
-            'local',
-          );
-        });
-      });
-
-      expect(document.querySelectorAll('.wandok-blur').length).toBeGreaterThan(0);
+      expect(document.getElementById('wandok-shadow-host')).not.toBeNull();
     });
   });
 });

--- a/apps/extension/src/content.tsx
+++ b/apps/extension/src/content.tsx
@@ -2,149 +2,53 @@ import { createRoot } from 'react-dom/client';
 
 import contentCss from '../public/content.css?inline';
 import { App } from './components/App';
-import { BLOCK_SELECTOR } from './config/constants';
-import { applyBlurEffect } from './utils/applyBlurEffect';
-import { extractTextNodes } from './utils/extractTextNodes';
-import { restoreSplitParagraphs } from './utils/restoreSplitParagraphs';
-import { restoreTextWrappers } from './utils/restoreTextWrappers';
-import { segmentSentences } from './utils/segmentSentences';
-import { splitParagraph } from './utils/splitParagraph';
+import { createInteractionHandler } from './utils/interactionHandler';
+import { createOverlayRenderer } from './utils/overlayRenderer';
+import { createSentenceMap } from './utils/sentenceMap';
+import { createVirtualParagraphState } from './utils/virtualParagraphState';
 
 interface StorageData {
   wandokEnabled?: boolean;
 }
 
-// 관리 대상 문단들을 저장할 Set
-const allBlockElements = new Set<HTMLElement>();
-
-// 이미 처리된 텍스트 노드를 추적하여 중복 처리 방지
-let processedNodes = new WeakSet<Node>();
+const sentenceMap = createSentenceMap();
+const state = createVirtualParagraphState();
+const renderer = createOverlayRenderer();
+const interaction = createInteractionHandler();
 
 let isEnabled = false;
+let focusedBlock: HTMLElement | null = null;
+let focusedVPIndex: number | null = null;
 
 /**
- * 특정 요소의 가장 가까운 문단(Block) 요소를 찾는 헬퍼 함수
+ * 블록의 특정 문장 인덱스에 spacer를 삽입하여 시각적으로 문단을 분리한다.
  */
-const getClosestBlock = (el: HTMLElement): HTMLElement | null => {
-  return el.closest(BLOCK_SELECTOR) as HTMLElement | null;
+const insertSpacer = (block: HTMLElement, sentenceIndex: number): void => {
+  const regions = sentenceMap.getRegions(block);
+  if (!regions || sentenceIndex >= regions.length) return;
+
+  const region = regions[sentenceIndex];
+  const { textNode, startOffset } = region;
+
+  const secondHalf = textNode.splitText(startOffset);
+
+  const spacer = document.createElement('br');
+  spacer.className = 'wandok-spacer';
+  secondHalf.parentNode?.insertBefore(spacer, secondHalf);
 };
 
 /**
- * 화이트리스트: 본문 콘텐츠 영역
- *
- * Brunch: .wrap_body, #ArticleView
- * Velog: .atom-one
+ * 모든 spacer를 제거하고 텍스트 노드를 정규화한다.
  */
-const CONTENT_SELECTORS =
-  'article, main, [role="main"], .post-content, .article-body, ' +
-  '.wrap_body, #ArticleView, .atom-one';
-
-/**
- * 블랙리스트: 인터랙티브/동적 요소
- */
-const EXCLUDED_SELECTORS = 'button, a, [onclick], [role="button"], nav, header, footer';
-
-/**
- * 요소가 처리 대상인지 확인하는 헬퍼 함수
- * - 본문 콘텐츠 영역 안에 있어야 함
- * - 인터랙티브 요소 안에 있으면 제외
- */
-const isArticleContent = (element: HTMLElement): boolean => {
-  if (!element.closest(CONTENT_SELECTORS)) return false;
-
-  if (element.closest(EXCLUDED_SELECTORS)) return false;
-
-  return true;
-};
-
-/**
- * 텍스트 노드를 문장 단위로 분리하고 이벤트 핸들러를 등록하는 함수
- */
-const processTextNode = (textNode: Node) => {
-  // 이미 처리된 노드는 건너뜀
-  if (processedNodes.has(textNode)) return;
-  processedNodes.add(textNode);
-
-  const initialParent = getClosestBlock(textNode.parentElement as HTMLElement);
-  if (!initialParent || initialParent === document.body) return;
-
-  // Shadow DOM 내부의 요소는 처리하지 않음
-  if (initialParent.closest('#wandok-shadow-host')) return;
-
-  // 본문 콘텐츠 영역 외의 요소는 처리하지 않음
-  if (!isArticleContent(textNode.parentElement as HTMLElement)) return;
-
-  allBlockElements.add(initialParent);
-
-  const sentences = segmentSentences(textNode.textContent || '');
-  const fragment = document.createDocumentFragment();
-
-  sentences.forEach((sentenceText) => {
-    const sentenceSpan = document.createElement('span');
-    sentenceSpan.textContent = sentenceText;
-    sentenceSpan.classList.add('wandok-text-wrapper');
-
-    // [기능 1] 클릭 시 문단 분리
-    // setTimeout으로 지연하여 호스트 페이지의 이벤트 전파가 완료된 후 DOM을 변경
-    sentenceSpan.addEventListener('click', () => {
-      if (!isEnabled) return;
-
-      setTimeout(() => {
-        splitParagraph(sentenceSpan);
-
-        const newParent = getClosestBlock(sentenceSpan);
-        if (newParent) {
-          allBlockElements.add(newParent);
-        }
-      }, 0);
-    });
-
-    // [기능 2] 마우스 호버 시 블러 처리
-    sentenceSpan.addEventListener('mouseenter', () => {
-      if (!isEnabled) return;
-      // ★ 핵심 수정: 고정된 변수가 아니라, 호버 시점의 "현재 부모"를 실시간으로 찾음
-      const currentBlock = getClosestBlock(sentenceSpan);
-      if (currentBlock) {
-        applyBlurEffect(currentBlock, allBlockElements, true);
-      }
-    });
-
-    sentenceSpan.addEventListener('mouseleave', () => {
-      if (!isEnabled) return;
-      const currentBlock = getClosestBlock(sentenceSpan);
-      if (currentBlock) {
-        applyBlurEffect(currentBlock, allBlockElements, false);
-      }
-    });
-
-    fragment.appendChild(sentenceSpan);
-  });
-
-  textNode.parentNode?.replaceChild(fragment, textNode);
-};
-
-/**
- * 요소 내의 모든 텍스트 노드를 처리하는 함수
- */
-const processElement = (element: HTMLElement) => {
-  // 이미 처리된 wandok wrapper는 건너뜀
-  if (element.classList?.contains('wandok-text-wrapper')) return;
-
-  const textNodes = extractTextNodes(element);
-  textNodes.forEach(processTextNode);
-};
-
-/**
- * 모든 블러 효과 제거
- */
-const clearAllBlurEffects = () => {
-  allBlockElements.forEach((element) => {
-    element.classList.remove('wandok-blur');
+const removeAllSpacers = (): void => {
+  document.querySelectorAll('.wandok-spacer').forEach((spacer) => {
+    const parent = spacer.parentNode;
+    spacer.remove();
+    parent?.normalize();
   });
 };
 
 const initFocusMode = () => {
-  /* Shadow DOM Setup for React Components */
   const shadowHost = document.createElement('div');
   shadowHost.id = 'wandok-shadow-host';
 
@@ -173,14 +77,66 @@ const initFocusMode = () => {
   const root = createRoot(rootElement);
   root.render(<App />);
 
+  const activateFeatures = () => {
+    renderer.init(shadowRoot);
+    sentenceMap.analyze(document.body);
+
+    window.addEventListener('scroll', () => {
+      if (focusedBlock) {
+        focusedBlock = null;
+        focusedVPIndex = null;
+        renderer.clear();
+      }
+    }, { passive: true });
+
+    interaction.activate(sentenceMap, {
+      onHover(block, regionIndex) {
+        focusedBlock = block;
+
+        const regions = sentenceMap.getRegions(block);
+        if (regions) {
+          const vps = state.getVirtualParagraphs(block, regions.length);
+          focusedVPIndex = vps.findIndex(
+            (vp) => regionIndex >= vp.startIndex && regionIndex < vp.endIndex,
+          );
+        }
+
+        renderer.renderBlur(sentenceMap, state, focusedBlock, focusedVPIndex);
+        window.dispatchEvent(new CustomEvent('wandok:focus-hover'));
+      },
+      onHoverEnd() {
+        focusedBlock = null;
+        focusedVPIndex = null;
+        renderer.clear();
+      },
+      onSplit(block, regionIndex) {
+        state.addSplit(block, regionIndex);
+        insertSpacer(block, regionIndex);
+        sentenceMap.reanalyzeBlock(block);
+        window.dispatchEvent(new CustomEvent('wandok:paragraph-split'));
+      },
+    });
+  };
+
+  const deactivateFeatures = () => {
+    interaction.deactivate();
+    renderer.clear();
+    state.clearAll();
+    sentenceMap.clear();
+    removeAllSpacers();
+    focusedBlock = null;
+    focusedVPIndex = null;
+  };
+
   const updateEnabledState = (enabled: boolean) => {
     isEnabled = enabled;
     if (enabled) {
       if (!shadowHost.parentNode) {
         document.body.appendChild(shadowHost);
       }
-      processElement(document.body);
+      activateFeatures();
     } else {
+      deactivateFeatures();
       shadowHost.remove();
     }
     window.dispatchEvent(new CustomEvent(enabled ? 'wandok:activated' : 'wandok:deactivated'));
@@ -197,41 +153,21 @@ const initFocusMode = () => {
     if (areaName === 'local' && changes.wandokEnabled) {
       const enabled = (changes.wandokEnabled.newValue as boolean | undefined) ?? false;
       updateEnabledState(enabled);
-
-      if (!enabled) {
-        clearAllBlurEffects();
-        restoreSplitParagraphs(allBlockElements);
-        restoreTextWrappers();
-        allBlockElements.clear();
-        processedNodes = new WeakSet();
-      }
     }
   });
 
-  /* Text Blur + Split Paragraph Logic */
-  // 초기 페이지 로드 시 텍스트 처리
-  processElement(document.body);
-
-  /* MutationObserver: SPA에서 동적으로 추가되는 콘텐츠 처리 */
   const observer = new MutationObserver((mutations) => {
+    if (!isEnabled) return;
+
     mutations.forEach((mutation) => {
       mutation.addedNodes.forEach((node) => {
         if (node.nodeType === Node.ELEMENT_NODE) {
           const element = node as HTMLElement;
 
-          // Shadow DOM 내부 요소는 무시
           if (element.id === 'wandok-shadow-host') return;
           if (element.closest('#wandok-shadow-host')) return;
 
-          // wandok-split-paragraph로 생성된 요소는 무시 (이미 처리된 span 포함)
-          if (element.classList?.contains('wandok-split-paragraph')) return;
-
-          // 이미 wandok-text-wrapper를 포함한 요소는 무시
-          if (element.classList?.contains('wandok-text-wrapper')) return;
-          if (element.querySelector('.wandok-text-wrapper')) return;
-
-          // 새로 추가된 요소 내의 텍스트 처리
-          processElement(element);
+          sentenceMap.analyze(element);
         }
       });
     });
@@ -244,4 +180,3 @@ const initFocusMode = () => {
 };
 
 initFocusMode();
-

--- a/apps/extension/src/utils/__tests__/extractTextNodes.test.ts
+++ b/apps/extension/src/utils/__tests__/extractTextNodes.test.ts
@@ -14,10 +14,8 @@ describe('extractTextNodes', () => {
     container.remove();
   });
 
-  // ==================== 정상 케이스 (Happy Path) ====================
-
-  describe('정상 케이스 (Happy Path)', () => {
-    it('단순 텍스트 노드를 추출해야 한다.', () => {
+  describe('텍스트 노드 추출', () => {
+    it('단순 텍스트 노드를 추출해야 한다', () => {
       container.innerHTML = '<p>Hello World!</p>';
 
       const result = extractTextNodes(container);
@@ -26,7 +24,7 @@ describe('extractTextNodes', () => {
       expect(result[0].textContent).toBe('Hello World!');
     });
 
-    it('여러 텍스트 노드를 추출해야 한다.', () => {
+    it('여러 텍스트 노드를 문서 순서대로 추출해야 한다', () => {
       container.innerHTML = '<h1>First</h1><p>Second</p><span>Third</span>';
 
       const result = extractTextNodes(container);
@@ -37,7 +35,18 @@ describe('extractTextNodes', () => {
       expect(result[2].textContent).toBe('Third');
     });
 
-    it('excludeTags로 지정해 놓은 태그 내부의 텍스트는 텍스트 노드 추출에서 제외해야 한다.', () => {
+    it('공백만 있는 텍스트 노드는 제외해야 한다', () => {
+      container.innerHTML = '<p>   </p><p>Hello</p>';
+
+      const result = extractTextNodes(container);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].textContent).toBe('Hello');
+    });
+  });
+
+  describe('태그 필터링', () => {
+    it('기본 제외 태그(SCRIPT, STYLE 등) 내부의 텍스트는 제외해야 한다', () => {
       container.innerHTML = `
         <p>Visible</p>
         <script>console.log("hidden")</script>
@@ -53,7 +62,7 @@ describe('extractTextNodes', () => {
       expect(result[0].textContent).toBe('Visible');
     });
 
-    it('BUTTON, A, LABEL, SUMMARY 태그 내부의 텍스트는 추출에서 제외해야 한다', () => {
+    it('인터랙티브 요소(BUTTON, A, LABEL, SUMMARY) 내부의 텍스트는 제외해야 한다', () => {
       container.innerHTML = `
         <p>Visible</p>
         <button>Click me</button>
@@ -67,20 +76,23 @@ describe('extractTextNodes', () => {
       expect(result).toHaveLength(1);
       expect(result[0].textContent).toBe('Visible');
     });
+
+    it('커스텀 excludeTags를 전달하면 해당 태그만 제외해야 한다', () => {
+      container.innerHTML = `
+        <p>Visible</p>
+        <span>Also visible</span>
+        <code>Excluded</code>
+      `;
+
+      const result = extractTextNodes(container, ['CODE']);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].textContent).toBe('Visible');
+      expect(result[1].textContent).toBe('Also visible');
+    });
   });
 
-  // ==================== 빈 값 / null / undefined 처리 ====================
-
-  describe('빈 값 / null / undefined 처리', () => {
-    it('공백만 있는 텍스트 노드는 제외해야 한다.', () => {
-      container.innerHTML = '<p>   </p><p>Hello</p>';
-
-      const result = extractTextNodes(container);
-
-      expect(result).toHaveLength(1);
-      expect(result[0].textContent).toBe('Hello');
-    });
-
+  describe('빈 입력 처리', () => {
     it('빈 컨테이너에서는 빈 배열을 반환해야 한다', () => {
       container.innerHTML = '';
 
@@ -89,83 +101,11 @@ describe('extractTextNodes', () => {
       expect(result).toEqual([]);
     });
 
-    it('null 또는 undefined일 때 빈 배열을 반환해야 한다.', () => {
+    it('root가 null이면 빈 배열을 반환해야 한다', () => {
       // @ts-expect-error 테스트를 위해 의도적으로 잘못된 타입 전달
-      expect(extractTextNodes(null)).toEqual([]);
-      // @ts-expect-error 테스트를 위해 의도적으로 잘못된 타입 전달
-      expect(extractTextNodes(undefined)).toEqual([]);
-    });
-  });
+      const result = extractTextNodes(null);
 
-  // ==================== 에러 상황 및 복구 ====================
-
-  describe('에러 상황 및 복구', () => {
-    it('매우 깊게 중첩된 요소에서도 텍스트 노드를 추출해야 한다.', () => {
-      container.innerHTML = '<div>'.repeat(50) + 'Deep Text' + '</div>'.repeat(50);
-
-      const result = extractTextNodes(container);
-
-      expect(result).toHaveLength(1);
-      expect(result[0].textContent).toBe('Deep Text');
-    });
-
-  });
-
-  // ==================== 중첩 구조 케이스 ====================
-
-  describe('중첩 구조 케이스', () => {
-    it('중첩된 요소에서 텍스트 노드를 추출해야 한다', () => {
-      container.innerHTML = '<div><p><span>Nested Text</span></p></div>';
-
-      const result = extractTextNodes(container);
-
-      expect(result).toHaveLength(1);
-      expect(result[0].textContent).toBe('Nested Text');
-    });
-
-    it('wandok-text-wrapper 클래스가 있는 요소 안의 텍스트는 제외해야 한다', () => {
-      container.innerHTML = `
-        <p>일반 텍스트</p>
-        <p><span class="wandok-text-wrapper">이미 처리된 텍스트</span></p>
-      `;
-
-      const result = extractTextNodes(container);
-
-      expect(result).toHaveLength(1);
-      expect(result[0].textContent).toBe('일반 텍스트');
-    });
-
-    it('여러 wandok-text-wrapper와 일반 텍스트가 섞여있을 때 일반 텍스트만 추출해야 한다', () => {
-      container.innerHTML = `
-        <div>
-          <p>첫 번째 일반 텍스트</p>
-          <p><span class="wandok-text-wrapper">처리된 문장 1</span></p>
-          <p>두 번째 일반 텍스트</p>
-          <p><span class="wandok-text-wrapper">처리된 문장 2</span></p>
-        </div>
-      `;
-
-      const result = extractTextNodes(container);
-
-      expect(result).toHaveLength(2);
-      expect(result[0].textContent).toBe('첫 번째 일반 텍스트');
-      expect(result[1].textContent).toBe('두 번째 일반 텍스트');
-    });
-
-    it('중첩된 wandok-text-wrapper 구조에서도 모두 제외해야 한다', () => {
-      container.innerHTML = `
-        <p>일반 텍스트</p>
-        <p>
-          <span class="wandok-text-wrapper">
-            <span class="wandok-text-wrapper">중첩된 처리</span>
-          </span>
-        </p>
-      `;
-
-      const result = extractTextNodes(container);
-
-      expect(result).toHaveLength(1);
-      expect(result[0].textContent).toBe('일반 텍스트');
+      expect(result).toEqual([]);
     });
   });
 });

--- a/apps/extension/src/utils/__tests__/interactionHandler.test.ts
+++ b/apps/extension/src/utils/__tests__/interactionHandler.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createInteractionHandler, type InteractionHandlerCallbacks } from '../interactionHandler';
+import { type SentenceMap } from '../sentenceMap';
+
+const createMockSentenceMap = (
+  hitTestResult: { block: HTMLElement; regionIndex: number } | null = null,
+): SentenceMap => ({
+  analyze: vi.fn(),
+  reanalyzeBlock: vi.fn(),
+  getRegions: vi.fn(),
+  getBlocks: vi.fn(() => new Set<HTMLElement>()),
+  invalidateRects: vi.fn(),
+  computeRects: vi.fn(),
+  hitTest: vi.fn(() => hitTestResult),
+  clear: vi.fn(),
+});
+
+const createMockCallbacks = (): InteractionHandlerCallbacks => ({
+  onHover: vi.fn(),
+  onHoverEnd: vi.fn(),
+  onSplit: vi.fn(),
+});
+
+describe('InteractionHandler', () => {
+  let block: HTMLElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    block = document.createElement('p');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('activate', () => {
+    it('document에 mousemove, click 리스너를 등록해야 한다', () => {
+      const addSpy = vi.spyOn(document, 'addEventListener');
+      const handler = createInteractionHandler();
+
+      handler.activate(createMockSentenceMap(), createMockCallbacks());
+
+      const eventTypes = addSpy.mock.calls.map(([type]) => type);
+      expect(eventTypes).toContain('mousemove');
+      expect(eventTypes).toContain('click');
+
+      handler.deactivate();
+      addSpy.mockRestore();
+    });
+
+    it('mousemove 시 hitTest 결과가 있으면 onHover를 호출해야 한다', () => {
+      const hitResult = { block, regionIndex: 1 };
+      const mockMap = createMockSentenceMap(hitResult);
+      const callbacks = createMockCallbacks();
+      const handler = createInteractionHandler();
+      handler.activate(mockMap, callbacks);
+
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 50 }));
+      vi.advanceTimersByTime(16);
+
+      expect(callbacks.onHover).toHaveBeenCalledWith(block, 1);
+
+      handler.deactivate();
+    });
+
+    it('mousemove 시 hitTest 결과가 없으면 onHoverEnd를 호출해야 한다', () => {
+      const mockMap = createMockSentenceMap(null);
+      const callbacks = createMockCallbacks();
+      const handler = createInteractionHandler();
+      handler.activate(mockMap, callbacks);
+
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 50 }));
+      vi.advanceTimersByTime(16);
+
+      expect(callbacks.onHoverEnd).toHaveBeenCalled();
+
+      handler.deactivate();
+    });
+
+    it('click 시 hitTest 결과가 있으면 onSplit을 호출해야 한다', () => {
+      const hitResult = { block, regionIndex: 2 };
+      const mockMap = createMockSentenceMap(hitResult);
+      const callbacks = createMockCallbacks();
+      const handler = createInteractionHandler();
+      handler.activate(mockMap, callbacks);
+
+      document.dispatchEvent(new MouseEvent('click', { clientX: 100, clientY: 50 }));
+
+      expect(callbacks.onSplit).toHaveBeenCalledWith(block, 2);
+
+      handler.deactivate();
+    });
+
+    it('click 시 hitTest 결과가 없으면 onSplit을 호출하지 않아야 한다', () => {
+      const mockMap = createMockSentenceMap(null);
+      const callbacks = createMockCallbacks();
+      const handler = createInteractionHandler();
+      handler.activate(mockMap, callbacks);
+
+      document.dispatchEvent(new MouseEvent('click', { clientX: 100, clientY: 50 }));
+
+      expect(callbacks.onSplit).not.toHaveBeenCalled();
+
+      handler.deactivate();
+    });
+
+    it('같은 프레임 내 여러 mousemove는 마지막 이벤트만 처리해야 한다', () => {
+      const hitResult = { block, regionIndex: 0 };
+      const mockMap = createMockSentenceMap(hitResult);
+      const callbacks = createMockCallbacks();
+      const handler = createInteractionHandler();
+      handler.activate(mockMap, callbacks);
+
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 10, clientY: 10 }));
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 20, clientY: 20 }));
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 30, clientY: 30 }));
+      vi.advanceTimersByTime(16);
+
+      expect(mockMap.hitTest).toHaveBeenCalledTimes(1);
+      expect(mockMap.hitTest).toHaveBeenCalledWith(30, 30);
+
+      handler.deactivate();
+    });
+  });
+
+  describe('deactivate', () => {
+    it('등록된 리스너를 모두 제거해야 한다', () => {
+      const removeSpy = vi.spyOn(document, 'removeEventListener');
+      const handler = createInteractionHandler();
+      handler.activate(createMockSentenceMap(), createMockCallbacks());
+
+      handler.deactivate();
+
+      const eventTypes = removeSpy.mock.calls.map(([type]) => type);
+      expect(eventTypes).toContain('mousemove');
+      expect(eventTypes).toContain('click');
+
+      removeSpy.mockRestore();
+    });
+
+    it('deactivate 후 이벤트에 반응하지 않아야 한다', () => {
+      const hitResult = { block, regionIndex: 0 };
+      const mockMap = createMockSentenceMap(hitResult);
+      const callbacks = createMockCallbacks();
+      const handler = createInteractionHandler();
+      handler.activate(mockMap, callbacks);
+      handler.deactivate();
+
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 50 }));
+      vi.advanceTimersByTime(16);
+      document.dispatchEvent(new MouseEvent('click', { clientX: 100, clientY: 50 }));
+
+      expect(callbacks.onHover).not.toHaveBeenCalled();
+      expect(callbacks.onSplit).not.toHaveBeenCalled();
+    });
+
+    it('activate 전에 호출해도 에러가 없어야 한다', () => {
+      const handler = createInteractionHandler();
+
+      expect(() => handler.deactivate()).not.toThrow();
+    });
+  });
+});

--- a/apps/extension/src/utils/__tests__/overlayRenderer.test.ts
+++ b/apps/extension/src/utils/__tests__/overlayRenderer.test.ts
@@ -1,0 +1,136 @@
+import { createShadowHost } from '@test/mocks/dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createOverlayRenderer } from '../overlayRenderer';
+import { type SentenceMap } from '../sentenceMap';
+import { type VirtualParagraphState } from '../virtualParagraphState';
+
+const createMockSentenceMap = (): SentenceMap => ({
+  analyze: vi.fn(),
+  reanalyzeBlock: vi.fn(),
+  getRegions: vi.fn(),
+  getBlocks: vi.fn(() => new Set<HTMLElement>()),
+  invalidateRects: vi.fn(),
+  computeRects: vi.fn(),
+  hitTest: vi.fn(),
+  clear: vi.fn(),
+});
+
+const createMockState = (): VirtualParagraphState => ({
+  addSplit: vi.fn(),
+  getVirtualParagraphs: vi.fn(() => []),
+  getAllSplits: vi.fn(() => []),
+  clearAll: vi.fn(),
+});
+
+describe('OverlayRenderer', () => {
+  let shadowRoot: ShadowRoot;
+  let hostId: string;
+
+  beforeEach(() => {
+    hostId = 'test-overlay-host';
+    const result = createShadowHost(hostId);
+    shadowRoot = result.shadowRoot;
+  });
+
+  afterEach(() => {
+    document.getElementById(hostId)?.remove();
+  });
+
+  describe('init', () => {
+    it('shadowRoot에 overlay 컨테이너를 생성해야 한다', () => {
+      const renderer = createOverlayRenderer();
+
+      renderer.init(shadowRoot);
+
+      const container = shadowRoot.querySelector('.wandok-overlay');
+      expect(container).not.toBeNull();
+    });
+
+    it('컨테이너가 pointer-events: none 스타일이어야 한다', () => {
+      const renderer = createOverlayRenderer();
+
+      renderer.init(shadowRoot);
+
+      const container = shadowRoot.querySelector('.wandok-overlay') as HTMLElement;
+      expect(container.style.pointerEvents).toBe('none');
+    });
+  });
+
+  describe('renderBlur', () => {
+    it('focusedBlock이 있으면 블러 오버레이를 생성해야 한다', () => {
+      const renderer = createOverlayRenderer();
+      renderer.init(shadowRoot);
+      const focusedBlock = document.createElement('p');
+
+      renderer.renderBlur(createMockSentenceMap(), createMockState(), focusedBlock, 0);
+
+      const blurDiv = shadowRoot.querySelector('.wandok-overlay-blur') as HTMLElement;
+      expect(blurDiv).not.toBeNull();
+      expect(blurDiv.style.backdropFilter).toBe('blur(15px) brightness(0.7)');
+    });
+
+    it('focusedBlock이 null이면 블러 오버레이를 생성하지 않아야 한다', () => {
+      const renderer = createOverlayRenderer();
+      renderer.init(shadowRoot);
+
+      renderer.renderBlur(createMockSentenceMap(), createMockState(), null, null);
+
+      const container = shadowRoot.querySelector('.wandok-overlay') as HTMLElement;
+      expect(container.children.length).toBe(0);
+    });
+
+    it('포커스 영역을 clip-path evenodd polygon으로 제외해야 한다', () => {
+      const renderer = createOverlayRenderer();
+      renderer.init(shadowRoot);
+      const focusedBlock = document.createElement('p');
+
+      renderer.renderBlur(createMockSentenceMap(), createMockState(), focusedBlock, 0);
+
+      const blurDiv = shadowRoot.querySelector('.wandok-overlay-blur') as HTMLElement;
+      expect(blurDiv.style.clipPath).toContain('polygon');
+      expect(blurDiv.style.clipPath).toContain('evenodd');
+    });
+
+    it('연속 호출 시 이전 오버레이를 교체해야 한다', () => {
+      const renderer = createOverlayRenderer();
+      renderer.init(shadowRoot);
+      const focusedBlock = document.createElement('p');
+
+      renderer.renderBlur(createMockSentenceMap(), createMockState(), focusedBlock, 0);
+      renderer.renderBlur(createMockSentenceMap(), createMockState(), focusedBlock, 0);
+
+      const container = shadowRoot.querySelector('.wandok-overlay') as HTMLElement;
+      expect(container.querySelectorAll('.wandok-overlay-blur').length).toBe(1);
+    });
+
+    it('init 전에 호출해도 에러가 없어야 한다', () => {
+      const renderer = createOverlayRenderer();
+      const focusedBlock = document.createElement('p');
+
+      expect(() =>
+        renderer.renderBlur(createMockSentenceMap(), createMockState(), focusedBlock, 0),
+      ).not.toThrow();
+    });
+  });
+
+  describe('clear', () => {
+    it('컨테이너 내부의 오버레이를 모두 제거해야 한다', () => {
+      const renderer = createOverlayRenderer();
+      renderer.init(shadowRoot);
+      const focusedBlock = document.createElement('p');
+      renderer.renderBlur(createMockSentenceMap(), createMockState(), focusedBlock, 0);
+
+      renderer.clear();
+
+      const container = shadowRoot.querySelector('.wandok-overlay') as HTMLElement;
+      expect(container.children.length).toBe(0);
+    });
+
+    it('init 전에 호출해도 에러가 없어야 한다', () => {
+      const renderer = createOverlayRenderer();
+
+      expect(() => renderer.clear()).not.toThrow();
+    });
+  });
+});

--- a/apps/extension/src/utils/__tests__/sentenceMap.test.ts
+++ b/apps/extension/src/utils/__tests__/sentenceMap.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createSentenceMap } from '../sentenceMap';
+
+describe('SentenceMap', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  describe('analyze', () => {
+    it('여러 문장이 포함된 블록을 분석하면 문장별 오프셋이 연속되어야 한다', () => {
+      container.innerHTML =
+        '<article><p>첫 번째 문장입니다. 두 번째 문장입니다.</p></article>';
+      const sentenceMap = createSentenceMap();
+
+      sentenceMap.analyze(container);
+
+      const p = container.querySelector('p') as HTMLElement;
+      const regions = sentenceMap.getRegions(p)!;
+      expect(regions.length).toBeGreaterThanOrEqual(2);
+      expect(regions[0].startOffset).toBe(0);
+      expect(regions[1].startOffset).toBe(regions[0].endOffset);
+      expect(regions[regions.length - 1].endOffset).toBe(
+        p.textContent!.length,
+      );
+    });
+
+    it('여러 블록이 있으면 각 블록의 regions를 독립적으로 생성해야 한다', () => {
+      container.innerHTML = `
+        <article>
+          <p>첫 번째 문단입니다.</p>
+          <p>두 번째 문단입니다.</p>
+        </article>
+      `;
+      const sentenceMap = createSentenceMap();
+
+      sentenceMap.analyze(container);
+
+      const paragraphs = container.querySelectorAll('p');
+      expect(sentenceMap.getRegions(paragraphs[0] as HTMLElement)).toBeDefined();
+      expect(sentenceMap.getRegions(paragraphs[1] as HTMLElement)).toBeDefined();
+    });
+
+    it('콘텐츠 영역(article) 밖의 텍스트는 분석하지 않아야 한다', () => {
+      container.innerHTML = `
+        <nav><p>네비게이션</p></nav>
+        <article><p>본문 텍스트입니다.</p></article>
+      `;
+      const sentenceMap = createSentenceMap();
+
+      sentenceMap.analyze(container);
+
+      const navP = container.querySelector('nav p') as HTMLElement;
+      const articleP = container.querySelector('article p') as HTMLElement;
+      expect(sentenceMap.getRegions(navP)).toBeUndefined();
+      expect(sentenceMap.getRegions(articleP)).toBeDefined();
+    });
+
+    it('같은 블록을 두 번 analyze해도 기존 regions를 덮어쓰지 않아야 한다', () => {
+      container.innerHTML = '<article><p>문장입니다.</p></article>';
+      const sentenceMap = createSentenceMap();
+      const p = container.querySelector('p') as HTMLElement;
+
+      sentenceMap.analyze(container);
+      const firstRegions = sentenceMap.getRegions(p);
+
+      sentenceMap.analyze(container);
+      const secondRegions = sentenceMap.getRegions(p);
+
+      expect(firstRegions).toBe(secondRegions);
+    });
+
+    it('region의 textNode가 원본 DOM 텍스트 노드의 참조여야 한다', () => {
+      container.innerHTML = '<article><p>문장입니다.</p></article>';
+      const sentenceMap = createSentenceMap();
+
+      sentenceMap.analyze(container);
+
+      const p = container.querySelector('p') as HTMLElement;
+      const regions = sentenceMap.getRegions(p)!;
+      expect(regions[0].textNode).toBe(p.firstChild);
+    });
+  });
+
+  describe('reanalyzeBlock', () => {
+    it('블록의 텍스트가 변경된 후 호출하면 새 오프셋을 반영해야 한다', () => {
+      container.innerHTML = '<article><p>원본 문장.</p></article>';
+      const sentenceMap = createSentenceMap();
+      const p = container.querySelector('p') as HTMLElement;
+
+      sentenceMap.analyze(container);
+      const originalRegions = sentenceMap.getRegions(p)!;
+
+      p.textContent = '변경된 첫 번째 문장. 변경된 두 번째 문장.';
+      sentenceMap.reanalyzeBlock(p);
+
+      const newRegions = sentenceMap.getRegions(p)!;
+      expect(newRegions).not.toBe(originalRegions);
+      expect(newRegions.length).toBeGreaterThanOrEqual(2);
+      expect(newRegions[newRegions.length - 1].endOffset).toBe(
+        p.textContent.length,
+      );
+    });
+
+    it('텍스트가 빈 문자열로 변경되면 해당 블록의 regions를 제거해야 한다', () => {
+      container.innerHTML = '<article><p>문장입니다.</p></article>';
+      const sentenceMap = createSentenceMap();
+      const p = container.querySelector('p') as HTMLElement;
+
+      sentenceMap.analyze(container);
+      expect(sentenceMap.getRegions(p)).toBeDefined();
+
+      p.textContent = '';
+      sentenceMap.reanalyzeBlock(p);
+
+      expect(sentenceMap.getRegions(p)).toBeUndefined();
+    });
+  });
+
+  describe('getRegions', () => {
+    it('분석되지 않은 블록은 undefined를 반환해야 한다', () => {
+      const sentenceMap = createSentenceMap();
+
+      const unknownBlock = document.createElement('p');
+
+      expect(sentenceMap.getRegions(unknownBlock)).toBeUndefined();
+    });
+  });
+
+  describe('getBlocks', () => {
+    it('분석된 모든 블록 요소의 Set을 반환해야 한다', () => {
+      container.innerHTML = `
+        <article>
+          <p>첫 번째.</p>
+          <p>두 번째.</p>
+        </article>
+      `;
+      const sentenceMap = createSentenceMap();
+
+      sentenceMap.analyze(container);
+
+      expect(sentenceMap.getBlocks().size).toBe(2);
+    });
+  });
+
+  describe('invalidateRects', () => {
+    it('여러 블록의 모든 region cachedRects를 null로 리셋해야 한다', () => {
+      container.innerHTML = `
+        <article>
+          <p>첫 번째 문단.</p>
+          <p>두 번째 문단.</p>
+        </article>
+      `;
+      const sentenceMap = createSentenceMap();
+      sentenceMap.analyze(container);
+
+      const paragraphs = container.querySelectorAll('p');
+      const regions1 = sentenceMap.getRegions(paragraphs[0] as HTMLElement)!;
+      const regions2 = sentenceMap.getRegions(paragraphs[1] as HTMLElement)!;
+      regions1[0].cachedRects = [new DOMRect()];
+      regions2[0].cachedRects = [new DOMRect()];
+
+      sentenceMap.invalidateRects();
+
+      expect(regions1[0].cachedRects).toBeNull();
+      expect(regions2[0].cachedRects).toBeNull();
+    });
+  });
+
+  describe('clear', () => {
+    it('모든 분석 데이터를 초기화해야 한다', () => {
+      container.innerHTML = '<article><p>문장입니다.</p></article>';
+      const sentenceMap = createSentenceMap();
+      sentenceMap.analyze(container);
+
+      sentenceMap.clear();
+
+      expect(sentenceMap.getBlocks().size).toBe(0);
+      expect(
+        sentenceMap.getRegions(container.querySelector('p') as HTMLElement),
+      ).toBeUndefined();
+    });
+
+    it('clear 후 같은 블록을 다시 analyze할 수 있어야 한다', () => {
+      container.innerHTML = '<article><p>문장입니다.</p></article>';
+      const sentenceMap = createSentenceMap();
+      sentenceMap.analyze(container);
+
+      sentenceMap.clear();
+      sentenceMap.analyze(container);
+
+      expect(sentenceMap.getBlocks().size).toBe(1);
+    });
+  });
+});

--- a/apps/extension/src/utils/__tests__/virtualParagraphState.test.ts
+++ b/apps/extension/src/utils/__tests__/virtualParagraphState.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { createVirtualParagraphState } from '../virtualParagraphState';
+
+describe('VirtualParagraphState', () => {
+  let block: HTMLElement;
+
+  beforeEach(() => {
+    block = document.createElement('p');
+  });
+
+  describe('addSplit', () => {
+    it('분리 인덱스를 추가하면 getAllSplits에 반영되어야 한다', () => {
+      const state = createVirtualParagraphState();
+
+      state.addSplit(block, 2);
+
+      const splits = state.getAllSplits();
+      expect(splits).toEqual([{ block, sentenceIndex: 2 }]);
+    });
+
+    it('인덱스 0은 무시해야 한다', () => {
+      const state = createVirtualParagraphState();
+
+      state.addSplit(block, 0);
+
+      expect(state.getAllSplits()).toHaveLength(0);
+    });
+
+    it('같은 인덱스를 중복 추가해도 하나만 저장해야 한다', () => {
+      const state = createVirtualParagraphState();
+
+      state.addSplit(block, 2);
+      state.addSplit(block, 2);
+
+      expect(state.getAllSplits()).toHaveLength(1);
+    });
+
+    it('서로 다른 블록의 분리는 독립적으로 저장해야 한다', () => {
+      const state = createVirtualParagraphState();
+      const block2 = document.createElement('p');
+
+      state.addSplit(block, 1);
+      state.addSplit(block2, 3);
+
+      expect(state.getVirtualParagraphs(block, 5)).toEqual([
+        { startIndex: 0, endIndex: 1 },
+        { startIndex: 1, endIndex: 5 },
+      ]);
+      expect(state.getVirtualParagraphs(block2, 5)).toEqual([
+        { startIndex: 0, endIndex: 3 },
+        { startIndex: 3, endIndex: 5 },
+      ]);
+    });
+  });
+
+  describe('getVirtualParagraphs', () => {
+    it('분리가 없으면 전체를 하나의 가상 문단으로 반환해야 한다', () => {
+      const state = createVirtualParagraphState();
+
+      const result = state.getVirtualParagraphs(block, 4);
+
+      expect(result).toEqual([{ startIndex: 0, endIndex: 4 }]);
+    });
+
+    it('단일 분리 시 두 개의 [start, end) 범위를 반환해야 한다', () => {
+      const state = createVirtualParagraphState();
+      state.addSplit(block, 2);
+
+      const result = state.getVirtualParagraphs(block, 4);
+
+      expect(result).toEqual([
+        { startIndex: 0, endIndex: 2 },
+        { startIndex: 2, endIndex: 4 },
+      ]);
+    });
+
+    it('비순차로 추가된 분리 인덱스를 정렬하여 범위를 생성해야 한다', () => {
+      const state = createVirtualParagraphState();
+      state.addSplit(block, 3);
+      state.addSplit(block, 1);
+
+      const result = state.getVirtualParagraphs(block, 5);
+
+      expect(result).toEqual([
+        { startIndex: 0, endIndex: 1 },
+        { startIndex: 1, endIndex: 3 },
+        { startIndex: 3, endIndex: 5 },
+      ]);
+    });
+  });
+
+  describe('getAllSplits', () => {
+    it('여러 블록의 분리 정보를 모두 포함해야 한다', () => {
+      const state = createVirtualParagraphState();
+      const block2 = document.createElement('p');
+
+      state.addSplit(block, 1);
+      state.addSplit(block2, 3);
+
+      const splits = state.getAllSplits();
+      expect(splits).toHaveLength(2);
+      expect(splits).toContainEqual({ block, sentenceIndex: 1 });
+      expect(splits).toContainEqual({ block: block2, sentenceIndex: 3 });
+    });
+  });
+
+  describe('clearAll', () => {
+    it('모든 블록의 분리 데이터를 초기화해야 한다', () => {
+      const state = createVirtualParagraphState();
+      state.addSplit(block, 1);
+      state.addSplit(block, 3);
+
+      state.clearAll();
+
+      expect(state.getAllSplits()).toHaveLength(0);
+      expect(state.getVirtualParagraphs(block, 4)).toEqual([
+        { startIndex: 0, endIndex: 4 },
+      ]);
+    });
+  });
+});

--- a/apps/extension/src/utils/domFilters.ts
+++ b/apps/extension/src/utils/domFilters.ts
@@ -1,0 +1,36 @@
+import { BLOCK_SELECTOR } from '../config/constants';
+
+/**
+ * 화이트리스트: 본문 콘텐츠 영역
+ *
+ * Brunch: .wrap_body, #ArticleView
+ * Velog: .atom-one
+ */
+const CONTENT_SELECTORS =
+  'article, main, [role="main"], .post-content, .article-body, ' +
+  '.wrap_body, #ArticleView, .atom-one';
+
+/**
+ * 블랙리스트: 인터랙티브/동적 요소
+ */
+const EXCLUDED_SELECTORS = 'button, a, [onclick], [role="button"], nav, header, footer';
+
+/**
+ * 특정 요소의 가장 가까운 문단(Block) 요소를 찾는 헬퍼 함수
+ */
+export const getClosestBlock = (el: HTMLElement): HTMLElement | null => {
+  return el.closest(BLOCK_SELECTOR) as HTMLElement | null;
+};
+
+/**
+ * 요소가 처리 대상인지 확인하는 헬퍼 함수
+ * - 본문 콘텐츠 영역 안에 있어야 함
+ * - 인터랙티브 요소 안에 있으면 제외
+ */
+export const isArticleContent = (element: HTMLElement): boolean => {
+  if (!element.closest(CONTENT_SELECTORS)) return false;
+
+  if (element.closest(EXCLUDED_SELECTORS)) return false;
+
+  return true;
+};

--- a/apps/extension/src/utils/extractTextNodes.ts
+++ b/apps/extension/src/utils/extractTextNodes.ts
@@ -19,10 +19,6 @@ export const extractTextNodes = (
           return NodeFilter.FILTER_REJECT;
         }
 
-        if (node.parentElement?.classList.contains('wandok-text-wrapper')) {
-          return NodeFilter.FILTER_REJECT;
-        }
-
         return NodeFilter.FILTER_ACCEPT;
       },
     },

--- a/apps/extension/src/utils/interactionHandler.ts
+++ b/apps/extension/src/utils/interactionHandler.ts
@@ -1,0 +1,101 @@
+import { type SentenceMap } from './sentenceMap';
+
+/**
+ * InteractionHandler가 감지한 사용자 동작에 대응하는 콜백.
+ * content.tsx가 각 콜백을 구현하여 블러 렌더링·문단 분리 등을 수행한다.
+ */
+export interface InteractionHandlerCallbacks {
+  onHover(block: HTMLElement, regionIndex: number): void;
+  onHoverEnd(): void;
+  onSplit(block: HTMLElement, regionIndex: number): void;
+}
+
+/**
+ * document 레벨에서 마우스 이벤트를 감지하여 문장 단위 인터랙션을 처리하는 모듈.
+ *
+ * 개별 요소에 이벤트 리스너를 등록하지 않고, document에 mousemove/click 리스너를
+ * 하나씩만 등록한다. mousemove는 requestAnimationFrame으로 스로틀링하여
+ * SentenceMap.hitTest()로 마우스 아래의 문장을 탐색한다.
+ *
+ * ```
+ * 마우스 이동 → hitTest(x, y) → 문장 발견 → onHover(block, regionIndex)
+ *                          → 문장 없음 → onHoverEnd()
+ *
+ * 마우스 클릭 → hitTest(x, y) → 문장 발견 → onSplit(block, regionIndex)
+ * ```
+ */
+export interface InteractionHandler {
+  activate(sentenceMap: SentenceMap, callbacks: InteractionHandlerCallbacks): void;
+  deactivate(): void;
+}
+
+/**
+ * document 레벨 mousemove/click 리스너로 사용자 인터랙션을 처리한다.
+ * 호스트 DOM의 개별 요소에 이벤트 리스너를 추가하지 않는다.
+ */
+export const createInteractionHandler = (): InteractionHandler => {
+  let mousemoveHandler: ((e: MouseEvent) => void) | null = null;
+  let clickHandler: ((e: MouseEvent) => void) | null = null;
+  let rafId: number | null = null;
+
+  /**
+   * document에 mousemove/click 리스너를 등록한다.
+   * mousemove는 requestAnimationFrame으로 스로틀링하여 프레임당 최대 1회 hitTest를 수행한다.
+   */
+  const activate = (
+    sentenceMap: SentenceMap,
+    callbacks: InteractionHandlerCallbacks,
+  ): void => {
+    let pendingEvent: MouseEvent | null = null;
+
+    /** rAF 콜백: 가장 마지막 mousemove 이벤트로 hitTest를 실행한다. */
+    const processMouseMove = () => {
+      rafId = null;
+      if (!pendingEvent) return;
+
+      const result = sentenceMap.hitTest(pendingEvent.clientX, pendingEvent.clientY);
+      pendingEvent = null;
+
+      if (result) {
+        callbacks.onHover(result.block, result.regionIndex);
+      } else {
+        callbacks.onHoverEnd();
+      }
+    };
+
+    mousemoveHandler = (e: MouseEvent) => {
+      pendingEvent = e;
+      if (rafId === null) {
+        rafId = requestAnimationFrame(processMouseMove);
+      }
+    };
+
+    clickHandler = (e: MouseEvent) => {
+      const result = sentenceMap.hitTest(e.clientX, e.clientY);
+      if (result) {
+        callbacks.onSplit(result.block, result.regionIndex);
+      }
+    };
+
+    document.addEventListener('mousemove', mousemoveHandler);
+    document.addEventListener('click', clickHandler);
+  };
+
+  /** 등록된 mousemove/click 리스너를 제거하고 대기 중인 rAF를 취소한다. */
+  const deactivate = (): void => {
+    if (mousemoveHandler) {
+      document.removeEventListener('mousemove', mousemoveHandler);
+      mousemoveHandler = null;
+    }
+    if (clickHandler) {
+      document.removeEventListener('click', clickHandler);
+      clickHandler = null;
+    }
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  };
+
+  return { activate, deactivate };
+};

--- a/apps/extension/src/utils/overlayRenderer.ts
+++ b/apps/extension/src/utils/overlayRenderer.ts
@@ -1,0 +1,136 @@
+import { type SentenceMap } from './sentenceMap';
+import { type VirtualParagraphState } from './virtualParagraphState';
+
+/**
+ * Shadow DOM 내부에 블러 오버레이를 렌더링하는 모듈.
+ *
+ * 사용자가 읽고 있는 문단(포커스 영역)을 제외한 나머지 화면을 흐리게 처리한다.
+ * 원본 DOM에는 어떤 변경도 가하지 않으며, Shadow DOM 내부에서만 동작한다.
+ *
+ * ```
+ * SentenceMap  ──→ 문장별 뷰포트 좌표 제공
+ *                     ↓
+ * OverlayRenderer ──→ 전체 화면 블러 + clip-path 홀로 포커스 영역 투명 처리
+ *                     ↑
+ * VirtualParagraphState ──→ 포커스 영역의 문장 범위 제공
+ * ```
+ */
+export interface OverlayRenderer {
+  /** Shadow DOM 내부에 오버레이 컨테이너를 생성한다. */
+  init(shadowRoot: ShadowRoot): void;
+  /** 포커스된 문단을 제외한 나머지 화면에 블러 오버레이를 렌더링한다. */
+  renderBlur(
+    sentenceMap: SentenceMap,
+    state: VirtualParagraphState,
+    focusedBlock: HTMLElement | null,
+    focusedVPIndex: number | null,
+  ): void;
+  /** 오버레이를 모두 제거한다. */
+  clear(): void;
+}
+
+/**
+ * Shadow DOM 내부에 블러 오버레이를 렌더링한다.
+ * 원본 DOM에는 어떤 변경도 가하지 않는다.
+ */
+export const createOverlayRenderer = (): OverlayRenderer => {
+  let container: HTMLElement | null = null;
+
+  /** Shadow DOM 내부에 fixed 위치의 오버레이 컨테이너를 생성하고 삽입한다. */
+  const init = (shadowRoot: ShadowRoot): void => {
+    container = document.createElement('div');
+    container.className = 'wandok-overlay';
+    container.style.position = 'fixed';
+    container.style.inset = '0';
+    container.style.pointerEvents = 'none';
+    container.style.zIndex = '2147483646';
+    shadowRoot.appendChild(container);
+  };
+
+  /**
+   * 포커스된 가상 문단의 문장 rect들을 합쳐 바운딩 rect를 계산한다.
+   * Virtual Paragraph가 없거나 rect를 계산할 수 없으면 null을 반환한다.
+   */
+  const getVPRect = (
+    sentenceMap: SentenceMap,
+    state: VirtualParagraphState,
+    block: HTMLElement,
+    vpIndex: number | null,
+  ): DOMRect | null => {
+    const regions = sentenceMap.getRegions(block);
+    if (!regions || vpIndex === null) return null;
+
+    const vps = state.getVirtualParagraphs(block, regions.length);
+    const focusedVP = vps[vpIndex];
+    if (!focusedVP) return null;
+
+    sentenceMap.computeRects(block);
+
+    let minLeft = Infinity;
+    let minTop = Infinity;
+    let maxRight = -Infinity;
+    let maxBottom = -Infinity;
+    let hasRects = false;
+
+    for (let i = focusedVP.startIndex; i < focusedVP.endIndex; i++) {
+      const region = regions[i];
+      if (!region.cachedRects) continue;
+
+      for (const rect of region.cachedRects) {
+        minLeft = Math.min(minLeft, rect.left);
+        minTop = Math.min(minTop, rect.top);
+        maxRight = Math.max(maxRight, rect.right);
+        maxBottom = Math.max(maxBottom, rect.bottom);
+        hasRects = true;
+      }
+    }
+
+    if (!hasRects) return null;
+    return new DOMRect(minLeft, minTop, maxRight - minLeft, maxBottom - minTop);
+  };
+
+  /**
+   * 전체 화면에 블러를 적용하되, 포커스된 문단 영역만 clip-path 홀로 투명하게 남긴다.
+   * focusedBlock이 null이면 아무것도 렌더링하지 않는다.
+   */
+  const renderBlur = (
+    sentenceMap: SentenceMap,
+    state: VirtualParagraphState,
+    focusedBlock: HTMLElement | null,
+    focusedVPIndex: number | null,
+  ): void => {
+    if (!container) return;
+    container.innerHTML = '';
+
+    if (!focusedBlock) return;
+
+    const holeRect =
+      getVPRect(sentenceMap, state, focusedBlock, focusedVPIndex) ??
+      focusedBlock.getBoundingClientRect();
+
+    const overlay = document.createElement('div');
+    overlay.className = 'wandok-overlay-blur';
+    overlay.style.position = 'fixed';
+    overlay.style.inset = '0';
+    overlay.style.backdropFilter = 'blur(15px) brightness(0.7)';
+    overlay.style.pointerEvents = 'none';
+    overlay.style.clipPath =
+      'polygon(evenodd, 0 0, 100% 0, 100% 100%, 0 100%, 0 0, ' +
+      `${holeRect.left}px ${holeRect.top}px, ` +
+      `${holeRect.left}px ${holeRect.bottom}px, ` +
+      `${holeRect.right}px ${holeRect.bottom}px, ` +
+      `${holeRect.right}px ${holeRect.top}px, ` +
+      `${holeRect.left}px ${holeRect.top}px, ` +
+      '0 0)';
+
+    container.appendChild(overlay);
+  };
+
+  /** 컨테이너 내부의 모든 오버레이 요소를 제거한다. */
+  const clear = (): void => {
+    if (!container) return;
+    container.innerHTML = '';
+  };
+
+  return { init, renderBlur, clear };
+};

--- a/apps/extension/src/utils/sentenceMap.ts
+++ b/apps/extension/src/utils/sentenceMap.ts
@@ -1,0 +1,233 @@
+/**
+ * ## SentenceMap — 원본 DOM을 변경하지 않는 문장 분석 모듈
+ *
+ * 웹 페이지의 텍스트를 문장 단위로 분석하고, 각 문장의 위치 정보를 관리한다.
+ * 원본 DOM을 읽기만 할 뿐 어떤 변경도 가하지 않는다.
+ *
+ * ### 핵심 구조: Block → SentenceRegion[]
+ *
+ * ```
+ * <article>
+ *   <p>첫 번째 문장. 두 번째 문장.</p>     ← Block (HTMLElement)
+ *   <p>세 번째 문장.</p>                ← Block (HTMLElement)
+ * </article>
+ *
+ * SentenceMap 내부 저장 구조:
+ * ┌─────────┬───────────────────────────────────────────────────┐
+ * │  Block  │  SentenceRegion[]                                 │
+ * ├─────────┼───────────────────────────────────────────────────┤
+ * │  <p#1>  │ [{ "첫 번째 문장. ", 0~9 }, { "두 번째 문장.", 9~18 }]  │
+ * │  <p#2>  │ [{ "세 번째 문장.", 0~7 }]                           │
+ * └─────────┴───────────────────────────────────────────────────┘
+ * ```
+ *
+ * - **SentenceRegion**: 하나의 문장이 텍스트 노드 내에서 차지하는 범위(startOffset, endOffset)와
+ *   뷰포트 좌표 캐시(cachedRects)를 담는 단위 데이터.
+ * - **SentenceMap**: 블록 요소를 키로, 해당 블록에 속한 SentenceRegion 배열을 값으로 관리하는
+ *   분석 결과 저장소. analyze()로 분석하고, hitTest()로 좌표 기반 문장 탐색,
+ *   computeRects()로 뷰포트 좌표 캐싱 등의 조회 기능을 제공한다.
+ *
+ * ### 사용 흐름
+ *
+ * 1. `analyze(root)` — 콘텐츠 영역의 텍스트를 블록별로 분석하여 SentenceRegion 생성
+ * 2. `hitTest(x, y)` — 마우스 좌표로 해당 문장의 block과 regionIndex를 탐색
+ * 3. `computeRects(block)` — 오버레이 렌더링을 위해 뷰포트 좌표를 계산·캐싱
+ * 4. `invalidateRects()` — 스크롤/리사이즈 시 캐시 무효화
+ * 5. `clear()` — 비활성화 시 전체 초기화
+ */
+
+import { getClosestBlock, isArticleContent } from './domFilters';
+import { extractTextNodes } from './extractTextNodes';
+import { segmentSentences } from './segmentSentences';
+
+/** 하나의 문장이 텍스트 노드 내에서 차지하는 범위와 캐싱된 뷰포트 좌표. */
+export interface SentenceRegion {
+  textNode: Text;
+  startOffset: number;
+  endOffset: number;
+  /** Range.getClientRects()로 계산한 뷰포트 좌표. 미계산 시 null. */
+  cachedRects: DOMRect[] | null;
+}
+
+/**
+ * 원본 DOM의 텍스트를 문장 단위로 분석하여 오프셋 정보를 관리하는 읽기 전용 모듈.
+ * 블록 요소별로 문장 region을 저장한다.
+ */
+export interface SentenceMap {
+  analyze(root: HTMLElement): void;
+  reanalyzeBlock(block: HTMLElement): void;
+  getRegions(block: HTMLElement): SentenceRegion[] | undefined;
+  getBlocks(): Set<HTMLElement>;
+  invalidateRects(): void;
+  computeRects(block: HTMLElement): void;
+  hitTest(x: number, y: number): { block: HTMLElement; regionIndex: number } | null;
+  clear(): void;
+}
+
+/** 텍스트 노드가 속한 콘텐츠 블록을 찾는다. 콘텐츠 영역 밖이거나 유효하지 않으면 null. */
+const findContentBlock = (textNode: Text): HTMLElement | null => {
+  const parent = textNode.parentElement;
+  if (!parent) return null;
+  if (!isArticleContent(parent)) return null;
+
+  const block = getClosestBlock(parent);
+  if (!block || block === document.body) return null;
+
+  return block;
+};
+
+/** 단일 텍스트 노드를 문장 단위로 분할하여 SentenceRegion 배열을 생성한다. */
+const createRegionsFromTextNode = (textNode: Text): SentenceRegion[] => {
+  const text = textNode.textContent ?? '';
+  const sentences = segmentSentences(text);
+
+  let offset = 0;
+  return sentences.map((sentence) => {
+    const region: SentenceRegion = {
+      textNode,
+      startOffset: offset,
+      endOffset: offset + sentence.length,
+      cachedRects: null,
+    };
+    offset += sentence.length;
+    return region;
+  });
+};
+
+/** caret 오프셋이 region의 범위 안에 있는지 확인한다. */
+const containsOffset = (region: SentenceRegion, offset: number): boolean => {
+  return offset >= region.startOffset && offset < region.endOffset;
+};
+
+/** 원본 DOM의 텍스트를 문장 단위로 분석하여 오프셋 정보를 저장한다. */
+export const createSentenceMap = (): SentenceMap => {
+  const blockRegions = new Map<HTMLElement, SentenceRegion[]>();
+  let analyzedBlocks = new WeakSet<HTMLElement>();
+
+  /** 텍스트 노드를 콘텐츠 영역 내 블록 단위로 그룹화한다. 이미 분석한 블록은 제외. */
+  const groupTextNodesByBlock = (textNodes: Text[]): Map<HTMLElement, Text[]> => {
+    const groups = new Map<HTMLElement, Text[]>();
+
+    for (const textNode of textNodes) {
+      const block = findContentBlock(textNode);
+      if (!block || analyzedBlocks.has(block)) continue;
+
+      if (!groups.has(block)) {
+        groups.set(block, []);
+      }
+      groups.get(block)!.push(textNode);
+    }
+
+    return groups;
+  };
+
+  /** 블록별 텍스트 노드로부터 region을 생성하고 등록한다. */
+  const registerBlocks = (blockTextNodes: Map<HTMLElement, Text[]>): void => {
+    for (const [block, textNodes] of blockTextNodes) {
+      analyzedBlocks.add(block);
+
+      const regions = textNodes.flatMap(createRegionsFromTextNode);
+      if (regions.length > 0) {
+        blockRegions.set(block, regions);
+      }
+    }
+  };
+
+  /**
+   * root 하위의 텍스트 노드를 블록 단위로 그룹화하고 문장별 오프셋을 계산한다.
+   * 이미 분석한 블록은 스킵하며, 콘텐츠 영역(article, main 등) 내부만 처리한다.
+   */
+  const analyze = (root: HTMLElement): void => {
+    const textNodes = extractTextNodes(root);
+    const blockTextNodes = groupTextNodesByBlock(textNodes);
+    registerBlocks(blockTextNodes);
+  };
+
+  /**
+   * 블록의 기존 분석 데이터를 삭제하고 다시 분석한다.
+   * spacer 삽입 등으로 텍스트 노드가 변경된 후 호출한다.
+   */
+  const reanalyzeBlock = (block: HTMLElement): void => {
+    blockRegions.delete(block);
+
+    const textNodes = extractTextNodes(block);
+    const regions = textNodes.flatMap(createRegionsFromTextNode);
+    if (regions.length > 0) {
+      blockRegions.set(block, regions);
+    }
+  };
+
+  /** 블록에 속한 문장 region 배열을 반환한다. 분석되지 않은 블록은 undefined. */
+  const getRegions = (block: HTMLElement): SentenceRegion[] | undefined => {
+    return blockRegions.get(block);
+  };
+
+  /** 분석된 모든 블록 요소의 Set을 반환한다. */
+  const getBlocks = (): Set<HTMLElement> => {
+    return new Set(blockRegions.keys());
+  };
+
+  /** 모든 region의 cachedRects를 null로 리셋한다. 스크롤/리사이즈 후 호출. */
+  const invalidateRects = (): void => {
+    for (const regions of blockRegions.values()) {
+      for (const region of regions) {
+        region.cachedRects = null;
+      }
+    }
+  };
+
+  /** Range.getClientRects()로 블록 내 각 region의 뷰포트 좌표를 계산하여 캐싱한다. */
+  const computeRects = (block: HTMLElement): void => {
+    const regions = blockRegions.get(block);
+    if (!regions) return;
+
+    for (const region of regions) {
+      const range = document.createRange();
+      range.setStart(region.textNode, region.startOffset);
+      range.setEnd(region.textNode, region.endOffset);
+      region.cachedRects = Array.from(range.getClientRects());
+    }
+  };
+
+  /**
+   * 뷰포트 좌표 (x, y)에 해당하는 문장 region을 찾는다.
+   * caretRangeFromPoint로 텍스트 노드/오프셋을 구한 뒤 region과 매칭한다.
+   */
+  const hitTest = (
+    x: number,
+    y: number,
+  ): { block: HTMLElement; regionIndex: number } | null => {
+    const caretRange = document.caretRangeFromPoint(x, y);
+    if (!caretRange) return null;
+
+    const { startContainer, startOffset } = caretRange;
+    if (startContainer.nodeType !== Node.TEXT_NODE) return null;
+
+    for (const [block, regions] of blockRegions) {
+      const regionIndex = regions.findIndex(
+        (region) =>
+          region.textNode === startContainer && containsOffset(region, startOffset),
+      );
+      if (regionIndex !== -1) return { block, regionIndex };
+    }
+
+    return null;
+  };
+
+  /** 모든 분석 데이터를 초기화한다. 비활성화 시 호출. */
+  const clear = (): void => {
+    blockRegions.clear();
+    analyzedBlocks = new WeakSet();
+  };
+
+  return {
+    analyze,
+    reanalyzeBlock,
+    getRegions,
+    getBlocks,
+    invalidateRects,
+    computeRects,
+    hitTest,
+    clear,
+  };
+};

--- a/apps/extension/src/utils/virtualParagraphState.ts
+++ b/apps/extension/src/utils/virtualParagraphState.ts
@@ -1,0 +1,111 @@
+/**
+ * 하나의 가상 문단이 차지하는 문장 범위.
+ * SentenceRegion 배열의 인덱스를 [startIndex, endIndex) 반개구간으로 표현한다.
+ *
+ * @example
+ * // 문장 5개인 블록에서 인덱스 2에서 분리하면:
+ * // VP1: { startIndex: 0, endIndex: 2 }  → 문장 0, 1
+ * // VP2: { startIndex: 2, endIndex: 5 }  → 문장 2, 3, 4
+ */
+interface VirtualParagraph {
+  startIndex: number;
+  endIndex: number;
+}
+
+/**
+ * 블록별 가상 문단 분리 상태를 관리하는 순수 데이터 구조.
+ *
+ * SentenceMap이 블록 내 문장을 분석한 뒤, 사용자가 클릭으로 문단을 나누면
+ * 이 모듈이 분리 지점(sentenceIndex)을 기록한다.
+ * OverlayRenderer는 이 분리 정보를 참조하여 포커스 영역의 범위를 결정한다.
+ *
+ * ```
+ * SentenceMap.analyze()        → 블록별 SentenceRegion[] 생성
+ *       ↓
+ * VirtualParagraphState.addSplit() → 분리 인덱스 기록
+ *       ↓
+ * VirtualParagraphState.getVirtualParagraphs() → VirtualParagraph[] 범위 반환
+ *       ↓
+ * OverlayRenderer.renderBlur() → 해당 범위의 rects로 블러 hole 렌더링
+ * ```
+ */
+export interface VirtualParagraphState {
+  addSplit(block: HTMLElement, sentenceIndex: number): void;
+  getVirtualParagraphs(block: HTMLElement, totalSentences: number): VirtualParagraph[];
+  getAllSplits(): { block: HTMLElement; sentenceIndex: number }[];
+  clearAll(): void;
+}
+
+/**
+ * 가상 문단 분리 상태를 관리하는 순수 데이터 구조.
+ * 원본 DOM을 변경하지 않고, 어떤 블록의 몇 번째 문장 앞에서 분리할지를 기록한다.
+ */
+export const createVirtualParagraphState = (): VirtualParagraphState => {
+  const splits = new Map<HTMLElement, Set<number>>();
+
+  /**
+   * 블록의 특정 문장 인덱스에 분리 지점을 추가한다.
+   * 인덱스 0은 무시한다 (첫 문장 앞에서 분리하는 것은 무의미).
+   */
+  const addSplit = (block: HTMLElement, sentenceIndex: number): void => {
+    if (sentenceIndex === 0) return;
+
+    if (!splits.has(block)) {
+      splits.set(block, new Set());
+    }
+    splits.get(block)!.add(sentenceIndex);
+  };
+
+  /**
+   * 블록의 분리 지점들을 기준으로 가상 문단 범위 배열을 반환한다.
+   * 각 범위는 [startIndex, endIndex) 형태이다.
+   *
+   * @example
+   * // 문장 5개, 인덱스 2에서 분리
+   * getVirtualParagraphs(block, 5)
+   * // → [{ startIndex: 0, endIndex: 2 }, { startIndex: 2, endIndex: 5 }]
+   */
+  const getVirtualParagraphs = (
+    block: HTMLElement,
+    totalSentences: number,
+  ): VirtualParagraph[] => {
+    const blockSplits = splits.get(block);
+    if (!blockSplits || blockSplits.size === 0) {
+      return [{ startIndex: 0, endIndex: totalSentences }];
+    }
+
+    const sorted = Array.from(blockSplits).sort((a, b) => a - b);
+    const result: VirtualParagraph[] = [];
+    let start = 0;
+
+    for (const splitIndex of sorted) {
+      result.push({ startIndex: start, endIndex: splitIndex });
+      start = splitIndex;
+    }
+    result.push({ startIndex: start, endIndex: totalSentences });
+
+    return result;
+  };
+
+  /**
+   * 모든 블록의 분리 정보를 평탄화하여 반환한다.
+   */
+  const getAllSplits = (): { block: HTMLElement; sentenceIndex: number }[] => {
+    const result: { block: HTMLElement; sentenceIndex: number }[] = [];
+    for (const [block, indices] of splits) {
+      for (const sentenceIndex of indices) {
+        result.push({ block, sentenceIndex });
+      }
+    }
+    return result;
+  };
+
+  /**
+   * 모든 분리 데이터를 초기화한다.
+   */
+  const clearAll = (): void => {
+    splits.clear();
+  };
+
+  return { addSplit, getVirtualParagraphs, getAllSplits, clearAll };
+};


### PR DESCRIPTION
- #65 에서 분리한 PR입니다.
# ⚠️ #68 머지 후 진행해주시길 바랍니다 ⚠️
# ⚠️ 머지 시 base를 `development`로 리타겟해주세요 ⚠️

<br />

# PR 작성 전 자가 점검 리스트
- [x] 가장 최근 브랜치를 pull하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] compare 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 점검했습니다.
- [x] 테스트 코드가 작성되어 있습니다.
- [x] 변경사항으로 인해 생성되는 경고가 없는 것을 확인했습니다.

---
<br />

# 관련 이슈
- #16 
- #28
- #29 
- #64 

---
<br />

# 무엇을 했나요?

- DOM 직접 수정 방식에서 가상 오버레이 방식으로 전환했습니다.
- 사용자 클릭 시 br 태그 삽입 외에 활성화·호버 시 **원본 DOM 조작이 완전히 제거**되었습니다. 🎉

<br />

### 1. 본문 영역 판별 로직 분리
- `content.tsx`에 있던 화이트리스트/블랙리스트 판별 로직을 `domFilters.ts` 모듈로 분리했습니다.

### 2. 문장 단위 분석 기능 추가
- `sentenceMap.ts`를 추가하여 페이지 텍스트를 문장 단위로 매핑하는 기능을 구현했습니다.

### 3. 가상 문단 상태 관리 추가
- `virtualParagraphState.ts`를 추가하여 사용자가 나눈 문단 위치를 원본 DOM 수정 없이 기억하도록 했습니다.

### 4. 오버레이 기반 블러 효과 전환
- `overlayRenderer.ts`를 추가하여 읽고 있는 문단 외 영역을 오버레이로 흐리게 표시하도록 했습니다.
- 기존 DOM 직접 수정 방식(`wandok-blur` 클래스)에서 오버레이 방식으로 전환했습니다.

### 5. 마우스 인터랙션 처리 추가
- `interactionHandler.ts`를 추가하여 마우스 위치로 문장을 감지하는 인터랙션을 처리합니다.

---
<br />

# 참고 사항
- `content.tsx`의 역할을 초기화·이벤트 리스너 등록으로 축소하고, 핵심 로직을 독립 모듈로 분산했습니다.